### PR TITLE
Replace - with _ for configmap names

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -233,7 +233,7 @@ func updateContainers(containers []api.Container, annotationValue, configMapVers
 	configmaps := strings.Split(annotationValue, ",")
 	for _, cmNameToUpdate := range configmaps {
 
-		configmapEnvar := "FABRIC8_" + strings.ToUpper(cmNameToUpdate) + "_CONFIGMAP"
+		configmapEnvar := "FABRIC8_" + strings.ToUpper(strings.Replace(cmNameToUpdate, "-", "_")) + "_CONFIGMAP"
 
 		for i := range containers {
 			envs := containers[i].Env


### PR DESCRIPTION
If the configmap name contains -, the controller generates an invalid name for an environment variable. For example, if my configMap is named `foo-config`, the controller attempts to create an envVar named `FABRIC8_FOO-CONFIG_CONFIGMAP`.

This is a straightforward fix for this issue. A more general purpose fix for other characters may be needed.