### PR TITLE
Removing problem introduced by  searching the configmap name again

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -232,29 +232,29 @@ func convertConfigMapToToken(cm *api.ConfigMap) string {
 func updateContainers(containers []api.Container, configMapVersion string, cmNameToUpdate string) bool {
 	// we can have multiple configmaps to update
 	answer := false
-  configmapEnvar := "FABRIC8_" + convertToEnvVarName(cmNameToUpdate) + "_CONFIGMAP"
-  for i := range containers {
-    envs := containers[i].Env
-    matched := false
-    for j := range envs {
-      if envs[j].Name == configmapEnvar {
-        matched = true
-        if envs[j].Value != configMapVersion {
-          glog.Infof("Updating %s to %s", configmapEnvar, configMapVersion)
-          envs[j].Value = configMapVersion
-          answer = true
-        }
-      }
-    }
-    // if no existing env var exists lets create one
-    if !matched {
-      e := api.EnvVar{
-        Name:  configmapEnvar,
-        Value: configMapVersion,
-      }
-      containers[i].Env = append(containers[i].Env, e)
-      answer = true
-    }
+	configmapEnvar := "FABRIC8_" + convertToEnvVarName(cmNameToUpdate) + "_CONFIGMAP"
+	for i := range containers {
+		envs := containers[i].Env
+		matched := false
+		for j := range envs {
+			if envs[j].Name == configmapEnvar {
+				matched = true
+				if envs[j].Value != configMapVersion {
+					glog.Infof("Updating %s to %s", configmapEnvar, configMapVersion)
+					envs[j].Value = configMapVersion
+					answer = true
+				}
+			}
+		}
+		// if no existing env var exists lets create one
+		if !matched {
+			e := api.EnvVar{
+				Name:  configmapEnvar,
+				Value: configMapVersion,
+			}
+			containers[i].Env = append(containers[i].Env, e)
+			answer = true
+		}
 	}
 	return answer
 }


### PR DESCRIPTION
Looking for the configmap  again inside the container update function introduces an error because all env vars corresponding to configmaps that didn't change are updated as well to the value of the config map that actually changed. 

Consider a deployment object with a container in which 
configmap.fabric8.io/update-on-change = cm1,cm2

Then modify cm1, and then modify cm2.
in the end both FABRIC8_CM1_CONFIGMAP and FABRIC8_CM2_CONFIGMAP could be set to the value of cm2.
